### PR TITLE
Revert "Fix/newline windows"

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	VERSION         string = "0.1.1"
+	VERSION         string = "0.1.0"
 	Baseuri         string = "https://www.kleinanzeigen.de"
 	Listuri         string = "/s-bestandsliste.html"
 	Defaultdir      string = "."

--- a/main.go
+++ b/main.go
@@ -131,11 +131,10 @@ func Main() int {
 		if conf.StatsCountAds == 1 {
 			adstr = "ad"
 		}
-		fmt.Printf("Successfully downloaded %d %s with %d images to %s.",
+		fmt.Printf("Successfully downloaded %d %s with %d images to %s.\n",
 			conf.StatsCountAds, adstr, conf.StatsCountImages, conf.Outdir)
-		fmt.Println()
 	} else {
-		fmt.Println("No ads found.")
+		fmt.Printf("No ads found.")
 	}
 
 	return 0


### PR DESCRIPTION
Reverts TLINDEN/kleingebaeck#18

That's NOT the fix. When building under windows the original code just works, it doesn't work when cross built on linux.